### PR TITLE
更新 yaml 文件，以因應kubernetes 和Helm 現行版本 

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,12 +736,6 @@ echo 192.168.99.100   purple.demo.com >> /etc/hosts
 brew install kubernetes-helm
 ```
 
-下載完後，我們記得要 Helm 把 Cluster 配置初始化
-
-```
-helm init
-```
-
 接下來讓我們安裝 Wordpress 的 [Chart](https://github.com/helm/charts/tree/master/stable/wordpress)，我們可以直接透過指令
 
 ```

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ kubectl edit deployments my-deployment
 接著我們會看到我們的 Yaml 檔
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -541,7 +541,7 @@ kubectl rollout history deployment my-deployment
 看到我們目前更改過的版本
 
 ```
-deployment.extensions/my-deployment
+deployment.apps/my-deployment
 REVISION  CHANGE-CAUSE
 1         <none>
 2         <none>
@@ -574,7 +574,7 @@ kubectl rollout undo deploy my-deployment --to-revision=2
 `deployment.yaml`
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: blue-nginx
@@ -593,7 +593,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: purple-nginx
@@ -670,24 +670,32 @@ purple-service   NodePort    10.107.21.77     <none>        80:32086/TCP   60s
 `ingress.yaml`
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: web
+  name: reverse-proxy-ingress
 spec:
   rules:
     - host: blue.demo.com
       http:
         paths:
-          - backend:
-              serviceName: blue-service
-              servicePort: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: blue-service
+                port:
+                  number: 80
     - host: purple.demo.com
       http:
         paths:
-          - backend:
-              serviceName: purple-service
-              servicePort: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: purple-service
+                port:
+                  number: 80
 ```
 
 我們一樣透過 `kubectl create -f ingress.yaml` 來建立我們的 ingress 物件。並使用 `kubectl get ingress` 來查看我們的 ingress 狀況：
@@ -825,7 +833,7 @@ helm create helm-demo
 `deployment.yaml`
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: blue-nginx
@@ -863,7 +871,7 @@ spec:
 `ingress.yaml`
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
@@ -947,7 +955,7 @@ spec:
 ```yaml
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "value-helm-demo.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
在 Kubernetes 升級到 v1.31 後，yaml有一些變動如下：

deployment kind 的 yml 不再支援 apiVersion: extension/v1beta1，直接改為 apps/v1。
ingress kind 的 yml，在 apiVersion 有所調整，extension/v1beta1 -> networking.k8s.io/v1，還有一些rule設定上的相應調整。
在 Helm 升級到 v3.* 後，移除了Tiller，不再記錄release，指令有以下調整：

第一次安裝後不再需要 helm init 指令來初始化 Tiller
helm delete RELEASE_NAME 有被保留，但移除了 --purge 參數
新的指令用於移除 released k8s， helm uninstall RELEASE_NAME